### PR TITLE
json-c: fix Apple Clang conversion warning

### DIFF
--- a/lib/json-c/json_object.c
+++ b/lib/json-c/json_object.c
@@ -709,7 +709,9 @@ int64_t json_object_get_int64(const struct json_object *jso)
 	case json_type_int:
 		return jso->o.c_int64;
 	case json_type_double:
-		if (jso->o.c_double >= INT64_MAX)
+		// INT64_MAX can't be exactly represented as a double
+		// so cast to tell the compiler it's ok to round up.
+		if (jso->o.c_double >= (double)INT64_MAX)
 			return INT64_MAX;
 		if (jso->o.c_double <= INT64_MIN)
 			return INT64_MIN;


### PR DESCRIPTION
Newer Apple Clang versions diagnose the implicit conversion of `INT64_MAX`
to `double` in the vendored json-c implementation. Since acvpproxy builds
with `-Werror`, the warning prevents a clean macOS build:

```text
lib/json-c/json_object.c:712:26: error: implicit conversion from
'long long' to 'double' changes value from 9223372036854775807 to
9223372036854775808 [-Werror,-Wimplicit-const-int-float-conversion]
```

Make the conversion explicit and retain the saturation behavior. This is a
direct backport of json-c commit
[`d0b87ee87b282e9b91a1af924050e217b0b2ae8b`](https://github.com/json-c/json-c/commit/d0b87ee87b282e9b91a1af924050e217b0b2ae8b).

Tested on:

- Apple clang 21.0.0 (`clang-2100.0.123.102`)
- Xcode 26.4.1 (17E202)
- arm64 macOS
- `make clean`
- `make -j2`
- focused `json_object_get_int64` checks for normal, upper-bound, and
  lower-bound conversion behavior

The full `tests/test_exec.sh` runner was also attempted. At this base commit,
several macOS sub-test builds fail before execution because their Makefiles do
not provide include paths for headers such as `base64.h`, `rbg_definition.h`,
and `amvp_definition.h`. Those baseline harness failures are unrelated to this
json-c change.
